### PR TITLE
Corrected italian bot definition

### DIFF
--- a/source/services/lex-bot/book_appointment/appointment_helpers.py
+++ b/source/services/lex-bot/book_appointment/appointment_helpers.py
@@ -25,7 +25,7 @@ def slot_types(language):
         "Italian": [
             {"sampleValue": {"value": "pulizia"}},
             {"sampleValue": {"value": "devitalizzazione"}},
-            {"sampleValue": {"value": "blanchiment"}},
+            {"sampleValue": {"value": "sbiancamento"}},
         ],
         "Spanish": [
             {"sampleValue": {"value": "limpieza"}},

--- a/source/services/lex-bot/book_appointment/test_appointment_helpers.py
+++ b/source/services/lex-bot/book_appointment/test_appointment_helpers.py
@@ -38,7 +38,7 @@ class BookAppointmentHelpersTest(TestCase):
             "Italian": [
                 {"sampleValue": {"value": "pulizia"}},
                 {"sampleValue": {"value": "devitalizzazione"}},
-                {"sampleValue": {"value": "blanchiment"}},
+                {"sampleValue": {"value": "sbiancamento"}},
             ],
             "Spanish": [
                 {"sampleValue": {"value": "limpieza"}},

--- a/source/services/lex-bot/leave_feedback/feedback_helpers.py
+++ b/source/services/lex-bot/leave_feedback/feedback_helpers.py
@@ -27,7 +27,7 @@ def feedback_utterances(language):
         "Italian": [
             {"utterance": "lasciare un feedback"},
             {"utterance": "Voglio lasciare un feedback"},
-            {"utterance": "risposta"},
+            {"utterance": "feedback"},
         ],
         "Spanish": [
             {"utterance": "dejar un comentario"},
@@ -70,13 +70,13 @@ def feedback_slot_messages(language, slot_type):
         },
         "Italian": {
             "firstName": {
-                "value": "Ciao, questo è l'interazione 1. Qual è il tuo nome?"
+                "value": "Ciao, questa è l'interazione 1. Qual è il tuo nome?"
             },
             "lastName": {
-                "value": "{firstName} questo è l'interazione 2. Qual è il tuo cognome?"
+                "value": "{firstName} questa è l'interazione 2. Qual è il tuo cognome?"
             },
             "feedback": {
-                "value": "{firstName} {lastName} questo è l'interazione 3. Qual è il tuo feedback?"
+                "value": "{firstName} {lastName} questa è l'interazione 3. Qual è il tuo feedback?"
             },
         },
         "Spanish": {
@@ -114,7 +114,7 @@ def closing_response(language):
             "value": "Succès! Ceci est l'interaction 4, la conversation se termine ici."
         },
         "Italian": {
-            "value": "Successo! Questo è l'interazione 4, la conversazione finisce qui."
+            "value": "Perfetto! Questa è l'interazione 4, la conversazione finisce qui."
         },
         "Spanish": {
             "value": "Éxito! Esta es la interacción 4, la conversación se encierra aquí."

--- a/source/services/lex-bot/leave_feedback/test_feedback_helpers.py
+++ b/source/services/lex-bot/leave_feedback/test_feedback_helpers.py
@@ -37,7 +37,7 @@ class BookAppointmentHelpersTest(TestCase):
             "Italian": [
                 {"utterance": "lasciare un feedback"},
                 {"utterance": "Voglio lasciare un feedback"},
-                {"utterance": "risposta"},
+                {"utterance": "feedback"},
             ],
             "Spanish": [
                 {"utterance": "dejar un comentario"},
@@ -90,13 +90,13 @@ class BookAppointmentHelpersTest(TestCase):
         },
         "Italian": {
             "firstName": {
-                "value": "Ciao, questo è l'interazione 1. Qual è il tuo nome?"
+                "value": "Ciao, questa è l'interazione 1. Qual è il tuo nome?"
             },
             "lastName": {
-                "value": "{firstName} questo è l'interazione 2. Qual è il tuo cognome?"
+                "value": "{firstName} questa è l'interazione 2. Qual è il tuo cognome?"
             },
             "feedback": {
-                "value": "{firstName} {lastName} questo è l'interazione 3. Qual è il tuo feedback?"
+                "value": "{firstName} {lastName} questa è l'interazione 3. Qual è il tuo feedback?"
             },
         },
         "Spanish": {
@@ -169,7 +169,7 @@ class BookAppointmentHelpersTest(TestCase):
                 "value": "Succès! Ceci est l'interaction 4, la conversation se termine ici."
             },
             "Italian": {
-                "value": "Successo! Questo è l'interazione 4, la conversazione finisce qui."
+                "value": "Perfetto! Questa è l'interazione 4, la conversazione finisce qui."
             },
             "Spanish": {
                 "value": "Éxito! Esta es la interacción 4, la conversación se encierra aquí."

--- a/source/services/lex-bot/order_pizza/order_helpers.py
+++ b/source/services/lex-bot/order_pizza/order_helpers.py
@@ -153,7 +153,7 @@ def slot_messages(language, slot_type_name):
                 "value": "Quelle taille aimeriez-vous (petit, moyen, grand, ou très-grand)?"
             },
             "Italian": {
-                "value": "Che dimensione vorresti, (piccola, media, grande o extra-grande)?"
+                "value": "Che dimensione vorresti (piccola, media, grande o extra-grande)?"
             },
             "Spanish": {
                 "value": "¿Qué tamaño le gustaría (pequeño, mediano, grande o extra-grande)?"
@@ -165,7 +165,7 @@ def slot_messages(language, slot_type_name):
         "crust": {
             "English": {"value": "What crust would you like, (thin or thick)?"},
             "French": {"value": "Quelle croûte aimeriez-vous (mince ou épaisse)?"},
-            "Italian": {"value": "Quale crosta vorresti, (sottile o spessa)?"},
+            "Italian": {"value": "Quale crosta vorresti (sottile o spessa)?"},
             "Spanish": {"value": "¿Qué corteza te gustaría, (fina o gruesa)?"},
             "German": {"value": "Welche Kruste möchten Sie (dünn oder dick)?"},
         },

--- a/source/services/lex-bot/order_pizza/order_helpers.py
+++ b/source/services/lex-bot/order_pizza/order_helpers.py
@@ -27,9 +27,9 @@ def order_utterances(language):
         ],
         "Italian": [
             {"utterance": "Vorrei ordinare una pizza"},
-            {"utterance": "ordina la pizza"},
-            {"utterance": "ordinare la pizza"},
-            {"utterance": "Voglio la pizza"},
+            {"utterance": "ordina una pizza"},
+            {"utterance": "ordinare una pizza"},
+            {"utterance": "Voglio una pizza"},
             {"utterance": "pizza"},
         ],
         "Spanish": [
@@ -65,7 +65,7 @@ def slot_types(slot_type_name, language):
             "Italian": [
                 {"sampleValue": {"value": "Greca"}},
                 {"sampleValue": {"value": "New York"}}, # NOSONAR this is a language specific word
-                {"sampleValue": {"value": "vegetariana"}},
+                {"sampleValue": {"value": "Vegetariana"}},
             ],
             "Spanish": [
                 {"sampleValue": {"value": "Griega"}},
@@ -153,7 +153,7 @@ def slot_messages(language, slot_type_name):
                 "value": "Quelle taille aimeriez-vous (petit, moyen, grand, ou très-grand)?"
             },
             "Italian": {
-                "value": "Che taglia vorresti, (piccola, media, grande o extra-grande)?"
+                "value": "Che dimensione vorresti, (piccola, media, grande o extra-grande)?"
             },
             "Spanish": {
                 "value": "¿Qué tamaño le gustaría (pequeño, mediano, grande o extra-grande)?"

--- a/source/services/lex-bot/order_pizza/test_order_helpers.py
+++ b/source/services/lex-bot/order_pizza/test_order_helpers.py
@@ -36,9 +36,9 @@ class TestOrderPizzaHelpers(TestCase):
             ],
             "Italian": [
                 {"utterance": "Vorrei ordinare una pizza"},
-                {"utterance": "ordina la pizza"},
-                {"utterance": "ordinare la pizza"},
-                {"utterance": "Voglio la pizza"},
+                {"utterance": "ordina una pizza"},
+                {"utterance": "ordinare una pizza"},
+                {"utterance": "Voglio una pizza"},
                 {"utterance": "pizza"},
             ],
             "Spanish": [
@@ -84,7 +84,7 @@ class TestOrderPizzaHelpers(TestCase):
                 "Italian": [
                     {"sampleValue": {"value": "Greca"}},
                     {"sampleValue": {"value": "New York"}},
-                    {"sampleValue": {"value": "vegetariana"}},
+                    {"sampleValue": {"value": "Vegetariana"}},
                 ],
                 "Spanish": [
                     {"sampleValue": {"value": "Griega"}},
@@ -207,7 +207,7 @@ class TestOrderPizzaHelpers(TestCase):
                     "value": "Quelle taille aimeriez-vous (petit, moyen, grand, ou très-grand)?"
                 },
                 "Italian": {
-                    "value": "Che taglia vorresti, (piccola, media, grande o extra-grande)?"
+                    "value": "Che dimensione vorresti, (piccola, media, grande o extra-grande)?"
                 },
                 "Spanish": {
                     "value": "¿Qué tamaño le gustaría (pequeño, mediano, grande o extra-grande)?"

--- a/source/services/lex-bot/order_pizza/test_order_helpers.py
+++ b/source/services/lex-bot/order_pizza/test_order_helpers.py
@@ -207,7 +207,7 @@ class TestOrderPizzaHelpers(TestCase):
                     "value": "Quelle taille aimeriez-vous (petit, moyen, grand, ou très-grand)?"
                 },
                 "Italian": {
-                    "value": "Che dimensione vorresti, (piccola, media, grande o extra-grande)?"
+                    "value": "Che dimensione vorresti (piccola, media, grande o extra-grande)?"
                 },
                 "Spanish": {
                     "value": "¿Qué tamaño le gustaría (pequeño, mediano, grande o extra-grande)?"
@@ -219,7 +219,7 @@ class TestOrderPizzaHelpers(TestCase):
             "crust": {
                 "English": {"value": "What crust would you like, (thin or thick)?"},
                 "French": {"value": "Quelle croûte aimeriez-vous (mince ou épaisse)?"},
-                "Italian": {"value": "Quale crosta vorresti, (sottile o spessa)?"},
+                "Italian": {"value": "Quale crosta vorresti (sottile o spessa)?"},
                 "Spanish": {"value": "¿Qué corteza te gustaría, (fina o gruesa)?"},
                 "German": {"value": "Welche Kruste möchten Sie (dünn oder dick)?"},
             },

--- a/source/services/lex-bot/other_intents/help_intent.py
+++ b/source/services/lex-bot/other_intents/help_intent.py
@@ -22,7 +22,7 @@ def closing_response(language):
     closing_response_value = {
         "English": {"value": "Try 'What is your name', 'Weather Forecast', 'Leave Feedback', 'Order Pizza', or 'Book Appointment'"},
         "French": {"value": "Essayez 'Quel est votre nom', 'Prévisions météo', 'Laisser les commentaires', 'Commander une pizza', ou 'Prendre rendez-vous'."},
-        "Italian": {"value": "Provare 'Qual è il tuo nome', 'Previsione del moto', 'lasciare un feedback', 'Ordina la pizza', o 'Fissa un appuntamento'."},
+        "Italian": {"value": "Provare 'Qual è il tuo nome', 'Previsioni del tempo', 'lasciare un feedback', 'Ordinare una pizza', o 'Fissare un appuntamento'."},
         "Spanish": {"value": "Intentar 'Cual es tu nombre', 'Como esta el clima', 'Dejar un comentario', 'Quiero pizza', o 'Reservar una cita'."},
         "German": {"value": "Versuchen 'Wie heißen Sie', 'Wettervorhersage', 'Hinterlasse ein Feedback', 'Pizza bestellen' oder, 'Einen Termin buchen'."},
     }
@@ -46,7 +46,7 @@ def utterances(language):
             {"utterance": "aiuto"},
             {"utterance": "aiutami"},
             {"utterance": "cosa sai"},
-            {"utterance": "rispondami qualcosa"},
+            {"utterance": "rispondimi qualcosa"},
         ],
         "Spanish": [
             {"utterance": "ayuda"},

--- a/source/services/lex-bot/other_intents/name_intent.py
+++ b/source/services/lex-bot/other_intents/name_intent.py
@@ -43,7 +43,7 @@ def utterances(language):
         "Italian": [
             {"utterance": "come ti chiami"},
             {"utterance": "qual è il tuo nome"},
-            {"utterance": "tu chi sei"},
+            {"utterance": "chi sei"},
         ],
         "Spanish": [
             {"utterance": "cual es tu nombre"},

--- a/source/services/lex-bot/other_intents/test_help_intent.py
+++ b/source/services/lex-bot/other_intents/test_help_intent.py
@@ -28,7 +28,7 @@ class BookAppointmentIntentTest(TestCase):
         closing_response_value = {
             "English": {"value": "Try 'What is your name', 'Weather Forecast', 'Leave Feedback', 'Order Pizza', or 'Book Appointment'"},
             "French": {"value": "Essayez 'Quel est votre nom', 'Prévisions météo', 'Laisser les commentaires', 'Commander une pizza', ou 'Prendre rendez-vous'."},
-            "Italian": {"value": "Provare 'Qual è il tuo nome', 'Previsione del moto', 'lasciare un feedback', 'Ordina la pizza', o 'Fissa un appuntamento'."},
+            "Italian": {"value": "Provare 'Qual è il tuo nome', 'Previsioni del tempo', 'lasciare un feedback', 'Ordinare una pizza', o 'Fissare un appuntamento'."},
             "Spanish": {"value": "Intentar 'Cual es tu nombre', 'Como esta el clima', 'Dejar un comentario', 'Quiero pizza', o 'Reservar una cita'."},
             "German": {"value": "Versuchen 'Wie heißen Sie', 'Wettervorhersage', 'Hinterlasse ein Feedback', 'Pizza bestellen' oder, 'Einen Termin buchen'."},
         }
@@ -64,7 +64,7 @@ class BookAppointmentIntentTest(TestCase):
                 {"utterance": "aiuto"},
                 {"utterance": "aiutami"},
                 {"utterance": "cosa sai"},
-                {"utterance": "rispondami qualcosa"},
+                {"utterance": "rispondimi qualcosa"},
             ],
             "Spanish": [
                 {"utterance": "ayuda"},

--- a/source/services/lex-bot/other_intents/test_name_intent.py
+++ b/source/services/lex-bot/other_intents/test_name_intent.py
@@ -60,7 +60,7 @@ class BookAppointmentIntentTest(TestCase):
             "Italian": [
                 {"utterance": "come ti chiami"},
                 {"utterance": "qual è il tuo nome"},
-                {"utterance": "tu chi sei"},
+                {"utterance": "chi sei"},
             ],
             "Spanish": [
                 {"utterance": "cual es tu nombre"},

--- a/source/services/lex-bot/weather_forecast/test_weather_forecast.py
+++ b/source/services/lex-bot/weather_forecast/test_weather_forecast.py
@@ -33,8 +33,8 @@ class TestWeatherHelpers(TestCase):
             ],
             "Italian": [
                 {"utterance": "com'è il meteo"},
-                {"utterance": "previsione del moto"},
-                {"utterance": "previsioni del tempo"},
+                {"utterance": "previsione del tempo"},
+                {"utterance": "che tempo fa"},
             ],
             "Spanish": [
                 {"utterance": "que la prevision del tiempo"},

--- a/source/services/lex-bot/weather_forecast/weather_helpers.py
+++ b/source/services/lex-bot/weather_forecast/weather_helpers.py
@@ -26,8 +26,8 @@ def utterances(language):
         ],
         "Italian": [
             {"utterance": "com'è il meteo"},
-            {"utterance": "previsione del moto"},
-            {"utterance": "previsioni del tempo"},
+            {"utterance": "previsione del tempo"},
+            {"utterance": "che tempo fa"},
         ],
         "Spanish": [
             {"utterance": "que la prevision del tiempo"},


### PR DESCRIPTION
*Issue #, if available:*
N/A

I am Italian and hence a native speaker and while testing the bot in Italian I realised that some of the utterances and some of the responses were not natural or outright wrong.

*Description of changes:*
Changes to the Italian bot definition of all intents in `source/services/lex-bot/*` plus respective tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
